### PR TITLE
Fix: Moved logging logic from UI, corrected work with shared prefs

### DIFF
--- a/app/src/main/java/com/settery/audioswitcher/LogManager.kt
+++ b/app/src/main/java/com/settery/audioswitcher/LogManager.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.widget.Toast
-import androidx.core.content.FileProvider
 import java.io.File
 import java.io.FileWriter
 import java.text.SimpleDateFormat
@@ -15,7 +14,6 @@ import java.util.LinkedList
 import java.util.Locale
 
 object LogManager {
-//    const val KEY_SERVICE_MODE = "logs_rec_key"
 
     private const val MAX_LOG_ENTRIES = 1000
     private val logBuffer = LinkedList<String>()
@@ -37,30 +35,24 @@ object LogManager {
     fun startRecording() {
         currLocale = Locale.getDefault()
         addLogInternal("LogManager", "USER: Logging started by user.", LogLevel.INFO)
-//        prefs.edit().putString(KEY_SERVICE_MODE, isRecordingEnabled.toString()).apply()
     }
 
     fun stopRecording() {
         addLogInternal("LogManager", "USER: Logging stopped by user.", LogLevel.INFO)
-//        prefs.edit().putString(KEY_SERVICE_MODE, isRecordingEnabled.toString()).apply()
-//        clearLogs()
     }
 
-    // Этот метод будет вызываться из вашего кода (например, из сервиса)
+    // Этот метод будет вызыввется из кода
     fun log(tag: String, message: String, level: LogLevel = LogLevel.DEBUG) {
         if (currentLoggingState == LoggingState.OFF) return
-        // INFO, WARNING, ERROR пишем всегда, но можно сделать более гранулярно
-        // if (!isRecordingEnabled && (level == LogLevel.DEBUG || level == LogLevel.VERBOSE)) return
-
         addLogInternal(tag, message, level)
     }
 
-    @Synchronized // Важно для многопоточного доступа
+    @Synchronized // maybe change it later
     private fun addLogInternal(tag: String, message: String, level: LogLevel) {
         val logEntry = "${dateFormat.format(Date())} ${level.name}/$tag: $message"
 
         if (logBuffer.size >= MAX_LOG_ENTRIES) {
-            logBuffer.removeAt(0) // Удаляем старую запись, если буфер полон
+            logBuffer.removeAt(0) // буфер полон -> удаляется самая старая запись
         }
         logBuffer.addLast(logEntry)
 
@@ -84,7 +76,7 @@ object LogManager {
         if (logString.isEmpty()) return null
 
         return try {
-            val file = File(context.cacheDir, fileName) // Используем cacheDir
+            val file = File(context.cacheDir, fileName)
             FileWriter(file).use {
                 it.write(getDeviceAndAppInfo(context))
                 it.write("\n\n--- LOGS ---\n")
@@ -122,43 +114,38 @@ object LogManager {
     }
 
 
-    fun onSendReportClicked(context: Context) {
-        val logFile = LogManager.getLogsAsFile(context)
-
-        val emailIntent = Intent(Intent.ACTION_SEND).apply {
-            type = "message/rfc822" // или "text/plain" если отправляете как текст
-            putExtra(Intent.EXTRA_EMAIL, arrayOf("pavelgrr7@hotmail.com"))
-            putExtra(Intent.EXTRA_SUBJECT, "App Bug Report - ${context.getString(R.string.app_name)}")
-
-            val emailBody = StringBuilder()
-            emailBody.append("Please describe the issue you experienced:\n\n\n")
-            emailBody.append("--------------------------------\n")
-            emailBody.append(getDeviceAndAppInfo(context))
-
-            if (logFile != null) {
-                val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", logFile)
-                putExtra(Intent.EXTRA_STREAM, uri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                emailBody.append("\n\nLogs are attached.")
-            } else {
-                emailBody.append("\n\nNo logs were recorded or an error occurred while preparing them.")
-                emailBody.append("\n\n--- RAW LOGS (IF AVAILABLE) ---\n") // Если файла нет, пробуем вставить как текст
-                emailBody.append(getLogsAsString())
-            }
-            putExtra(Intent.EXTRA_TEXT, emailBody.toString())
-        }
-
-        try {
-            context.startActivity(Intent.createChooser(emailIntent, "Send bug report via..."))
-        } catch (ex: ActivityNotFoundException) {
-            Toast.makeText(context, "No email client installed.", Toast.LENGTH_SHORT).show()
-            // Можно скопировать логи в буфер обмена как fallback
-            // val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            // val clip = ClipData.newPlainText("App Logs", LogManager.getLogsAsStringWith deviceInfo)
-            // clipboard.setPrimaryClip(clip)
-            // Toast.makeText(context, "Logs copied to clipboard.", Toast.LENGTH_LONG).show()
-        }
-    }
+//    fun onSendReportClicked(context: Context) {
+//        val logFile = LogManager.getLogsAsFile(context)
+//
+//        val emailIntent = Intent(Intent.ACTION_SEND).apply {
+//            type = "message/rfc822" // или "text/plain" если отправляете как текст
+//            putExtra(Intent.EXTRA_EMAIL, arrayOf("pavelgrr7@hotmail.com"))
+//            putExtra(Intent.EXTRA_SUBJECT, "App Bug Report - ${context.getString(R.string.app_name)}")
+//
+//            val emailBody = StringBuilder()
+//            emailBody.append("Please describe the issue you experienced:\n\n\n")
+//            emailBody.append("--------------------------------\n")
+//            emailBody.append(getDeviceAndAppInfo(context))
+//
+//            if (logFile != null) {
+//                val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", logFile)
+//                putExtra(Intent.EXTRA_STREAM, uri)
+//                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+//                emailBody.append("\n\nLogs are attached.")
+//            } else {
+//                emailBody.append("\n\nNo logs were recorded or an error occurred while preparing them.")
+//                emailBody.append("\n\n--- RAW LOGS (IF AVAILABLE) ---\n")
+//                emailBody.append(getLogsAsString())
+//            }
+//            putExtra(Intent.EXTRA_TEXT, emailBody.toString())
+//        }
+//
+//        try {
+//            context.startActivity(Intent.createChooser(emailIntent, "Send bug report via..."))
+//        } catch (ex: ActivityNotFoundException) {
+//            Toast.makeText(context, "No email client installed.", Toast.LENGTH_SHORT).show()
+//        }
+//    }
 }
 
 enum class LogLevel {

--- a/app/src/main/java/com/settery/audioswitcher/MainActivity.kt
+++ b/app/src/main/java/com/settery/audioswitcher/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -35,9 +36,6 @@ class MainActivity : ComponentActivity() {
         viewModel.currentMode.observe(this) { mode ->
             VolumeButtonService.updateServiceMode(this, mode)
         }
-        viewModel.loggingState.observe(this) { loggingState ->
-            LogManager.setLoggingState(loggingState)
-        }
         LogManager.initialize(application)
 
         requestIgnoreBatteryOptimizations()
@@ -47,32 +45,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             AudioSwitcherTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    val currentMode by viewModel.currentMode.observeAsState(
-                        initial = viewModel.currentMode.value ?: Mode.OFF
-                    )
-//                    val loggingState by viewModel.loggingState.observeAsState(
-//                        initial = viewModel.loggingState.value ?: LoggingState.OFF
-//                    )
                     MainScreen(
                         modifier = Modifier.padding(innerPadding),
-                        currentMode = currentMode,
-                        onModeSelected = { newMode -> viewModel.setMode(newMode) },
-                        onEnableServiceClicked = {
-                            if (!isAccessibilityServiceEnabled(this, VolumeButtonService::class.java)) {
-                                openAccessibilitySettings(this)
-                            }
-                        },
-                        onLoggingStateSelected = { newState -> viewModel.setLoggingState(newState)
-                            when(newState) {
-                                LoggingState.ACTIVE -> LogManager.startRecording()
-                                LoggingState.OFF -> {
-                                    LogManager.stopRecording()
-                                    LogManager.onSendReportClicked(this)
-                                }
-                            }
-                        },
-                        isAccessibilityServiceEnabled = isAccessibilityServiceEnabled(this, VolumeButtonService::class.java)
-                    )
+                        viewModel = viewModel,
+                        )
                 }
             }
         }
@@ -132,6 +108,10 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onStop() {
+        super.onStop()
+
+    }
 }
 
 fun isAccessibilityServiceEnabled(

--- a/app/src/main/java/com/settery/audioswitcher/ViewModel.kt
+++ b/app/src/main/java/com/settery/audioswitcher/ViewModel.kt
@@ -1,10 +1,21 @@
 package com.settery.audioswitcher
 
 import android.app.Application
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
+import android.widget.Toast
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.settery.audioswitcher.LogManager.getLogsAsString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import androidx.core.content.FileProvider
+
 
 const val KEY_MODE = "key_mode"
 const val KEY_LOGGING = "key_logging"
@@ -12,8 +23,8 @@ const val KEY_LOGGING = "key_logging"
 class ServiceViewModel(application: Application) : AndroidViewModel(application) {
     private val _currentMode = MutableLiveData<Mode>()
     val currentMode: LiveData<Mode> = _currentMode
-    private val _loggingState = MutableLiveData<LoggingState>()
-    val loggingState: LiveData<LoggingState> = _loggingState
+    private val _loggingState = MutableStateFlow(LoggingState.OFF)
+    val loggingState = _loggingState.asStateFlow()
 
     private val sharedPrefs = application.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
 
@@ -22,32 +33,97 @@ class ServiceViewModel(application: Application) : AndroidViewModel(application)
         loadLoggingState()
     }
 
-    fun setMode(mode: Mode) {
-        _currentMode.value = mode
-        saveMode(mode)
+    private fun loadLoggingState() {
+        val savedStateName = sharedPrefs.getString(KEY_LOGGING, LoggingState.OFF.name)
+        _loggingState.value = try {
+            LoggingState.valueOf(savedStateName ?: LoggingState.OFF.name)
+        } catch (e: IllegalArgumentException) {
+            LoggingState.OFF // Если в SharedPreferences сохранилось что-то некорректное
+        }
+
+        // Синхронизируем LogManager с загруженным состоянием
+        if (_loggingState.value == LoggingState.ACTIVE) {
+            LogManager.startRecording()
+        } else {
+            LogManager.stopRecording() // или просто убедиться, что isRecordingEnabled = false
+        }
     }
 
-    fun setLoggingState(ls: LoggingState) {
-        _loggingState.value = ls
-        saveLoggingState(ls)
+    fun toggleLoggingState() {
+        val currentState = _loggingState.value
+        val newState = if (currentState == LoggingState.ACTIVE) {
+            LoggingState.OFF
+        } else {
+            LoggingState.ACTIVE
+        }
 
+        if (newState == LoggingState.ACTIVE) {
+            LogManager.startRecording()
+        } else {
+            LogManager.stopRecording()
+        }
+
+        // рекомпозиция UI
+        _loggingState.value = newState
+
+        viewModelScope.launch {
+            saveLoggingState(newState)
+        }
+    }
+
+    fun sendEmailWithAttachment(context: Context, logFile: File?) {
+        val emailIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "message/rfc822" // или "text/plain" если отправляете как текст
+            putExtra(Intent.EXTRA_EMAIL, arrayOf("pavelgrr7@hotmail.com"))
+            putExtra(Intent.EXTRA_SUBJECT, "App Bug Report - ${context.getString(R.string.app_name)}")
+
+            val emailBody = StringBuilder()
+            emailBody.append("Please describe the issue you experienced:\n\n\n")
+            emailBody.append("--------------------------------\n")
+
+            if (logFile != null) {
+                val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", logFile)
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                emailBody.append("\n\nLogs are attached.")
+            } else {
+                emailBody.append("\n\nNo logs were recorded or an error occurred while preparing them.")
+                emailBody.append("\n\n--- RAW LOGS (IF AVAILABLE) ---\n")
+                emailBody.append(getLogsAsString())
+            }
+            putExtra(Intent.EXTRA_TEXT, emailBody.toString())
+        }
+
+        try {
+            context.startActivity(Intent.createChooser(emailIntent, "Send bug report via..."))
+        } catch (ex: ActivityNotFoundException) {
+            Toast.makeText(context, "No email client installed.", Toast.LENGTH_SHORT).show()
+        }
+
+    }
+
+    fun onEnableServiceClicked() {
+        if (!isAccessibilityServiceEnabled(getApplication(), VolumeButtonService::class.java)) {
+            openAccessibilitySettings(getApplication())
+        }
+    }
+
+    private fun saveLoggingState(state: LoggingState) {
+        sharedPrefs.edit().putString(KEY_LOGGING, state.name).apply()
     }
 
     fun saveMode(mode: Mode) {
         sharedPrefs.edit().putString(KEY_MODE, mode.name).apply()
     }
 
-    fun saveLoggingState(ls: LoggingState) {
-        sharedPrefs.edit().putString(KEY_LOGGING, ls.name).apply()
+    fun setMode(mode: Mode) {
+        _currentMode.value = mode
+        saveMode(mode)
     }
 
     fun loadMode() {
         val modeName = sharedPrefs.getString(KEY_MODE, Mode.OFF.name) ?: Mode.OFF.name
         _currentMode.value = Mode.valueOf(modeName)
-    }
-    fun loadLoggingState() {
-        val state = sharedPrefs.getString(KEY_LOGGING, LoggingState.OFF.name) ?: LoggingState.OFF.name
-        _loggingState.value = LoggingState.valueOf(state)
     }
 }
 enum class Mode{


### PR DESCRIPTION
Following the MVVM pattern, the compose 'MainScreen' function have been re-imagened and the logging blocks have been moved to ViewModel. Sending logs has also been moved from LoggingManager, because it is not logging, but sending logs